### PR TITLE
FOGL-9652 Cleanup unit test for use with valgrind

### DIFF
--- a/tests/test_metadata.cpp
+++ b/tests/test_metadata.cpp
@@ -21,6 +21,7 @@ extern "C"
 	PLUGIN_HANDLE plugin_init(ConfigCategory *config,
 							  OUTPUT_HANDLE *outHandle,
 							  OUTPUT_STREAM output);
+	void plugin_shutdown(PLUGIN_HANDLE handle);
 	int called = 0;
 
 	void Handler(void *handle, READINGSET *readings)
@@ -51,6 +52,8 @@ TEST(METADATA, MetadataDisabled)
 	readings->push_back(in);
 
 	ReadingSet *readingSet = new ReadingSet(readings);
+	readings->clear();
+	delete readings;
 	plugin_ingest(handle, (READINGSET *)readingSet);
 
 	vector<Reading *> results = outReadings->getAllReadings();
@@ -60,6 +63,10 @@ TEST(METADATA, MetadataDisabled)
 
 	vector<Datapoint *> points = out->getReadingData();
 	ASSERT_EQ(points.size(), 1);
+
+	delete outReadings;
+	delete config;
+	plugin_shutdown(handle);
 }
 
 TEST(METADATA, MetadataAddDataPoints)
@@ -83,6 +90,8 @@ TEST(METADATA, MetadataAddDataPoints)
 	readings->push_back(in);
 
 	ReadingSet *readingSet = new ReadingSet(readings);
+	readings->clear();
+	delete readings;
 	plugin_ingest(handle, (READINGSET *)readingSet);
 
 	vector<Reading *> results = outReadings->getAllReadings();
@@ -92,6 +101,10 @@ TEST(METADATA, MetadataAddDataPoints)
 
 	vector<Datapoint *> points = out->getReadingData();
 	ASSERT_EQ(points.size(), 2);
+
+	delete outReadings;
+	delete config;
+	plugin_shutdown(handle);
 }
 
 TEST(METADATA, MetadataAddSubs)
@@ -115,6 +128,8 @@ TEST(METADATA, MetadataAddSubs)
 	readings->push_back(in);
 
 	ReadingSet *readingSet = new ReadingSet(readings);
+	readings->clear();
+	delete readings;
 	plugin_ingest(handle, (READINGSET *)readingSet);
 
 	vector<Reading *> results = outReadings->getAllReadings();
@@ -126,6 +141,10 @@ TEST(METADATA, MetadataAddSubs)
 	ASSERT_EQ(points.size(), 2);
 	Datapoint *dp = out->getDatapoint("Source");
 	ASSERT_STREQ(dp->getData().toStringValue().c_str(), "Camera 2");
+
+	delete outReadings;
+	delete config;
+	plugin_shutdown(handle);
 }
 
 TEST(METADATA, INTEGER_MIN_MAX_LIMITS)
@@ -149,6 +168,8 @@ TEST(METADATA, INTEGER_MIN_MAX_LIMITS)
 	readings->push_back(in);
 
 	ReadingSet *readingSet = new ReadingSet(readings);
+	readings->clear();
+	delete readings;
 	plugin_ingest(handle, (READINGSET *)readingSet);
 
 	vector<Reading *> results = outReadings->getAllReadings();
@@ -166,6 +187,10 @@ TEST(METADATA, INTEGER_MIN_MAX_LIMITS)
 
 	ASSERT_EQ(points[2]->getName(), "INT2");
 	ASSERT_EQ(points[2]->getData().toInt(), -2147483647);
+
+	delete outReadings;
+	delete config;
+	plugin_shutdown(handle);
 }
 
 TEST(METADATA, LONG_MIN_MAX_LIMITS)
@@ -189,6 +214,8 @@ TEST(METADATA, LONG_MIN_MAX_LIMITS)
 	readings->push_back(in);
 
 	ReadingSet *readingSet = new ReadingSet(readings);
+	readings->clear();
+	delete readings;
 	plugin_ingest(handle, (READINGSET *)readingSet);
 
 	vector<Reading *> results = outReadings->getAllReadings();
@@ -206,6 +233,10 @@ TEST(METADATA, LONG_MIN_MAX_LIMITS)
 
 	ASSERT_EQ(points[2]->getName(), "LONG2");
 	ASSERT_EQ(points[2]->getData().toInt(), -9223372036854775807);
+
+	delete outReadings;
+	delete config;
+	plugin_shutdown(handle);
 }
 
 TEST(METADATA, MetadataNestedJSON)
@@ -229,6 +260,8 @@ TEST(METADATA, MetadataNestedJSON)
 	readings->push_back(in);
 
 	ReadingSet *readingSet = new ReadingSet(readings);
+	readings->clear();
+	delete readings;
 	plugin_ingest(handle, (READINGSET *)readingSet);
 
 	vector<Reading *> results = outReadings->getAllReadings();
@@ -247,4 +280,8 @@ TEST(METADATA, MetadataNestedJSON)
 
 	ASSERT_EQ(points[2]->getName(), "Location");
 	ASSERT_EQ(points[2]->getData().toStringValue(), "NY");
+
+	delete outReadings;
+	delete config;
+	plugin_shutdown(handle);
 }


### PR DESCRIPTION
==2470477== 
==2470477== HEAP SUMMARY:
==2470477==     in use at exit: 40 bytes in 1 blocks
==2470477==   total heap usage: 102,450 allocs, 102,449 frees, 265,812,465 bytes allocated
==2470477== 
==2470477== LEAK SUMMARY:
==2470477==    definitely lost: 0 bytes in 0 blocks
==2470477==    indirectly lost: 0 bytes in 0 blocks
==2470477==      possibly lost: 0 bytes in 0 blocks
==2470477==    still reachable: 40 bytes in 1 blocks
==2470477==         suppressed: 0 bytes in 0 blocks
==2470477== Reachable blocks (those to which a pointer was found) are not shown.
==2470477== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==2470477== 
==2470477== For lists of detected and suppressed errors, rerun with: -s
==2470477== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
foglamp@ub20:~/fledge-filter-metadata/tests/build$ 
